### PR TITLE
[WIP] Fix for coexistence with ember-maybe-in-element

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-in-element": "^0.1.3",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.17.0",
     "loader.js": "^4.2.3",

--- a/tests/integration/maybe-in-element-test.js
+++ b/tests/integration/maybe-in-element-test.js
@@ -1,0 +1,18 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('maybe-in-element', 'Integration | maybe-in-element', {
+  integration: true
+});
+
+test('works with maybe-in-element', function(assert) {
+  this.render(hbs`
+      <div id="test-destination-element"></div>
+      {{#if ready}}
+        {{#maybe-in-element destinationElement false}}Some text{{/maybe-in-element}}
+      {{/if}}
+    `);
+  this.set('destinationElement', document.querySelector('#test-destination-element'));
+  this.set('ready', true);
+  assert.dom('#test-destination-element').containsText('Some text', 'The content has been rendered in the destination element');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,7 +1790,7 @@ ember-ajax@^3.0.0:
   dependencies:
     ember-cli-babel "^6.0.0"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.11.0.tgz#79cb184bac3c05bfe181ddc306bac100ab1f9493"
   dependencies:
@@ -2093,6 +2093,12 @@ ember-load-initializers@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz#4919eaf06f6dfeca7e134633d8c05a6c9921e6e7"
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
+
+ember-maybe-in-element@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-0.1.3.tgz#1c89be49246e580c1090336ad8be31e373f71b60"
+  dependencies:
+    ember-cli-babel "^6.11.0"
 
 ember-qunit@^3.2.2:
   version "3.2.2"


### PR DESCRIPTION
This is a bit ugly, but the order the transforms are applied seems not to be the same for all Ember versions. For Ember 2.8 this was failing, as the polyfill transform was applied before the maybe transform, so a non-existing `-in-element` would remain in the template...

Ember 1.13 is still failing, needs https://github.com/DockYard/ember-maybe-in-element/pull/7 to be merged and released.

@cibernox fyi!